### PR TITLE
Adding alpha support

### DIFF
--- a/Source/VSTheme.m
+++ b/Source/VSTheme.m
@@ -117,7 +117,12 @@ static UIColor *colorWithHexString(NSString *hexString, NSNumber *alpha);
 		return cachedColor;
     
 	NSString *colorString = [self stringForKey:key];
-    NSNumber *number = [NSNumber numberWithFloat:[self floatForKey:[NSString stringWithFormat:@"%@Alpha", key]]];
+    NSNumber *number;
+    if ( [self objectForKey:[NSString stringWithFormat:@"%@Alpha", key]]) {
+        number = [NSNumber numberWithFloat:[self floatForKey:[NSString stringWithFormat:@"%@Alpha", key]]];
+    }
+
+    
 	UIColor *color = colorWithHexString(colorString, number);
 	if (color == nil)
 		color = [UIColor blackColor];


### PR DESCRIPTION
Small change to add alpha support. Looks for xAlpha in the plist (where x is the same key as the colour key) and defaults to 1.0f if not found.
