### PR TITLE
Keep a strong reference to the parent theme

### DIFF
--- a/Source/VSTheme.h
+++ b/Source/VSTheme.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSUInteger, VSTextCaseTransform) {
 - (id)initWithDictionary:(NSDictionary *)themeDictionary;
 
 @property (nonatomic, strong) NSString *name;
-@property (nonatomic, weak) VSTheme *parentTheme; /*can inherit*/
+@property (nonatomic, strong) VSTheme *parentTheme; /*can inherit*/
 
 - (BOOL)boolForKey:(NSString *)key;
 - (NSString *)stringForKey:(NSString *)key;


### PR DESCRIPTION
If the `VSThemeLoader` goes out of scope while you have a reference to a
`VSTheme`, then the only reference to the parent theme will be through the
weak `parentTheme` property. This will eventually get cleaned up, leaving you
with an empty reference and no theme inheritence.

The fix is to make the `parentTheme` property a strong reference.
