### PR TITLE
Add support for using variables in Plist values to reference other keys

### DIFF
--- a/Demo/DB5Demo/DB5.plist
+++ b/Demo/DB5Demo/DB5.plist
@@ -6,8 +6,10 @@
 	<dict>
 		<key>backgroundColor</key>
 		<string>708090</string>
-		<key>labelTextColor</key>
+		<key>mainTextColor</key>
 		<string>ececec</string>
+		<key>labelTextColor</key>
+		<string>$mainTextColor</string>
 		<key>labelFont</key>
 		<string>Avenir-Medium</string>
 		<key>labelFontSize</key>

--- a/Source/VSTheme.m
+++ b/Source/VSTheme.m
@@ -45,6 +45,12 @@ static UIColor *colorWithHexString(NSString *hexString);
 - (id)objectForKey:(NSString *)key {
 
 	id obj = [self.themeDictionary valueForKeyPath:key];
+    if ([obj isKindOfClass:[NSString class]]) {
+        NSString *str = (NSString *)obj;
+        if ([str rangeOfString:@"$"].location == 0) {
+            return [self objectForKey:[str substringFromIndex:1]];
+        }
+    }
 	if (obj == nil && self.parentTheme != nil)
 		obj = [self.parentTheme objectForKey:key];
 	return obj;


### PR DESCRIPTION
This add the ability to prefix a plist value with $ in order to have it reference another key within the plist. Common values can then be reused in the theme without having to reenter them. For example, one could have many keys with a value of '$mainTextColor', and then a single 'mainTextColor' key that references the actual color value. This allows for easier theming when a standard set of colors or numeric values are used throughout an app.
